### PR TITLE
fix: don't define more than once

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,9 @@ const formatters: Record<string, Intl.NumberFormat> = {};
 
 export default function NumberFlow(props: NumberFlowProps) {
   onMount(() => {
-    NumberFlowElement.define();
+    if (!customElements.get('number-flow')) {
+      NumberFlowElement.define();
+    }
   });
 
   const localesString = createMemo(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,13 +45,9 @@ export type NumberFlowProps = JSX.HTMLAttributes<NumberFlowElement> & {
 // Serialize to strings b/c React:
 const formatters: Record<string, Intl.NumberFormat> = {};
 
-export default function NumberFlow(props: NumberFlowProps) {
-  onMount(() => {
-    if (!customElements.get('number-flow')) {
-      NumberFlowElement.define();
-    }
-  });
+NumberFlowElement.define();
 
+export default function NumberFlow(props: NumberFlowProps) {
   const localesString = createMemo(
     () => (props.locales ? JSON.stringify(props.locales) : ''),
     [props.locales],


### PR DESCRIPTION
It seems that if I go to a page with the Number element and come back it tries to redefine it again when its already there.